### PR TITLE
Add support for UIButton (using setAttributedTitle:forState:)

### DIFF
--- a/Pod/Classes/JPAttributedString.h
+++ b/Pod/Classes/JPAttributedString.h
@@ -13,6 +13,7 @@
 
 #import "NSAttributedString+JPAttributedString.h"
 #import "NSString+JPAttributedString.h"
+#import "UIButton+JPAttributedString.h"
 #import "UILabel+JPAttributedString.h"
 #import "UITextField+JPAttributedString.h"
 #import "UITextView+JPAttributedString.h"

--- a/Pod/Classes/UIButton+JPAttributedString.h
+++ b/Pod/Classes/UIButton+JPAttributedString.h
@@ -1,0 +1,35 @@
+//
+//  UIButton+JPAttributedString.h
+//  Pods
+//
+//  Created by Bryan Oltman on 10/13/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@class JPStringAttribute;
+
+@interface UIButton (JPAttributedString)
+
+/**
+ *  Appends an attributed string to a UIButton's titleLabel
+ *
+ *  @param string     NSString used to create NSAttributedString's string
+ *  @param attributes JPStringAttribute used as NSAttributedString's attributes
+ *
+ *  @return Newly created NSAttributedString
+ */
+- (NSAttributedString *)jp_appendString:(NSString *)string attributes:(JPStringAttribute *)attributes;
+
+/**
+ *  Appends an attributed string to a UIButton's titleLabel
+ *
+ *  @param string NSString used to create NSAttributedString's string
+ *  @param block  void(^)(JPStringAttribute *make) block to configure JPStringAttribute
+ *
+ *  @return Newly created NSAttributedString
+ */
+- (NSAttributedString *)jp_appendString:(NSString *)string attributesBlock:(void(^)(JPStringAttribute *make))block;
+
+@end

--- a/Pod/Classes/UIButton+JPAttributedString.m
+++ b/Pod/Classes/UIButton+JPAttributedString.m
@@ -1,0 +1,41 @@
+//
+//  UIButton+JPAttributedString.m
+//  Pods
+//
+//  Created by Bryan Oltman on 10/13/15.
+//
+//
+
+#import "UIButton+JPAttributedString.h"
+
+#import "JPStringAttribute.h"
+
+@implementation UIButton (JPAttributedString)
+
+- (NSAttributedString *)jp_appendString:(NSString *)string attributes:(JPStringAttribute *)attributes {
+    NSMutableAttributedString *retString = [[NSMutableAttributedString alloc] initWithAttributedString:self.titleLabel.attributedText];
+    
+    [retString appendAttributedString:[[NSAttributedString alloc] initWithString:string
+                                                                      attributes:[attributes attributedDictionary]]];
+    
+    [self setAttributedTitle:retString forState:UIControlStateNormal];
+    
+    return retString;
+}
+
+- (NSAttributedString *)jp_appendString:(NSString *)string attributesBlock:(void(^)(JPStringAttribute *make))block {
+    NSMutableAttributedString *retString = [[NSMutableAttributedString alloc] initWithAttributedString:self.titleLabel.attributedText];
+    JPStringAttribute *stringAttribute = [[JPStringAttribute alloc] init];
+    if (block) {
+        block(stringAttribute);
+    }
+    
+    [retString appendAttributedString:[[NSAttributedString alloc] initWithString:string
+                                                                      attributes:[stringAttribute attributedDictionary]]];
+    
+    [self setAttributedTitle:retString forState:UIControlStateNormal];
+    
+    return retString;
+}
+
+@end


### PR DESCRIPTION
`UIButton` has the fun requirement that text be set using `set(Attributed)Title:forState:`, so the `UILabel` category in this pod doesn't play nicely with it. I've added an analog for `UIButton`.
